### PR TITLE
hostマシンからポート8000でつながるように修正

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     container_name: nginx-dl
     image: nginx
     ports:
-      - "${IP}:80:80"
+      - "${IP}:8000:80"
     volumes:
       - ./:/var/www
       - ./docker/nginx/default.conf:/etc/nginx/conf.d/default.conf

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -1,5 +1,5 @@
 server {
-  listen 8000;
+  listen 80;
   root /var/www/my-app/public;
   error_log /var/log/nginx/error.log warn;
   index index.php index.html;


### PR DESCRIPTION
こんにちは。
ブログ拝見しました。
非常に簡潔な説明で理解しやすかったです。

自身のローカルでコンテナを立てたところ、ホストマシンからブラウザで、laravelのindex.phpにアクセスできませんでした。
おそらく、公開ポート設定とlisten設定のポート番号が原因と思われます。
ブログの例通り、8000でアクセスできるように修正しています。

以上、ご確認のほどよろしくお願いいたします。

